### PR TITLE
MPVView: Limit demuxer cache size correctly

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -124,6 +124,7 @@ internal class MPVView(context: Context, attrs: AttributeSet) : SurfaceView(cont
         MPVLib.setOptionString("tls-ca-file", "${this.context.filesDir.path}/cacert.pem")
         // Limit demuxer cache to 32 MiB, the default is too high for mobile devices
         MPVLib.setOptionString("demuxer-max-bytes", "${32 * 1024 * 1024}")
+        MPVLib.setOptionString("demuxer-max-back-bytes", "${32 * 1024 * 1024}")
     }
 
     fun playFile(filePath: String) {


### PR DESCRIPTION
The backbuffer has a separate limit, which defaults to 400MB too.