### PR TITLE
jni/event: ignore log messages with invalid UTF-8

### DIFF
--- a/app/src/main/jni/event.cpp
+++ b/app/src/main/jni/event.cpp
@@ -38,6 +38,13 @@ static void sendEventToJava(JNIEnv *env, int event) {
 }
 
 static void sendLogMessageToJava(JNIEnv *env, mpv_event_log_message *msg) {
+    // filter the most obvious cases of invalid utf-8
+    int invalid = 0;
+    for (int i = 0; msg->text[i]; i++)
+        invalid |= msg->text[i] == 0xc0 || msg->text[i] == 0xc1 || msg->text[i] >= 0xf5;
+    if (invalid)
+        return;
+
     jstring jprefix = env->NewStringUTF(msg->prefix);
     jstring jtext = env->NewStringUTF(msg->text);
 


### PR DESCRIPTION
Java aborts when that is passed to NewStringUTF(), which happens
because stats.lua uses a 0xfd byte in its output.